### PR TITLE
[BUGFIX] Corrigir problema ao criar documento com mais de uma assinatura

### DIFF
--- a/lib/clicksign/document.rb
+++ b/lib/clicksign/document.rb
@@ -14,7 +14,7 @@ module Clicksign
 
     def self.create(file, params = {})
       signers = params.delete(:signers)
-      params['signers[]'] = [signers].flatten(1) if signers
+      params['signers'] = [signers].flatten(1) if signers
 
       request :post,
         api_url('documents'),

--- a/spec/clicksign_spec.rb
+++ b/spec/clicksign_spec.rb
@@ -43,7 +43,7 @@ describe Clicksign::Document do
         'document[archive][original]' => file,
         message: message,
         skip_email: skip_email,
-        'signers[]'  => [signers],
+        'signers'  => [signers],
       }, { accept: 'json' }).and_return({})
 
       Clicksign::Document.create(file, {


### PR DESCRIPTION
## Problema

Quando usamos o metodo create da Clicksign::Document, com mais de uma assinatura no signers, a API do clicksign estava salvando somente a ultima assinatura do Array.
## Solução

Como a função create_list esta funcionando, usei ela como base para encontrar a solução. Percebi que a mesma enviava o parâmetro como simples, apenas 'signers', já o create enviava o parâmetro como multiplos, assim 'signers[]', então acredito que a API tenha mudado e a gem não foi alterada.
